### PR TITLE
Fix up bake all.

### DIFF
--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -200,6 +200,10 @@ class BakeFixtureFactoryCommand extends BakeCommand
      */
     public function thisTableShouldBeBaked(string $table, ConsoleIo $io): bool
     {
+        if (!$table) {
+            return false;
+        }
+
         $tableClassName = $this->plugin ?: Configure::read('App.namespace');
         $tableClassName .= "\Model\Table\\{$table}Table";
 


### PR DESCRIPTION
When having a base class Table, this fixes it to not crash.

> The table  could not be found... in /var/www/html/src/Model/Table/
